### PR TITLE
feat(themes): Add template functions for Date

### DIFF
--- a/internal/cvrender/html/html.go
+++ b/internal/cvrender/html/html.go
@@ -55,6 +55,118 @@ func getTemplateFunctions() template.FuncMap {
 		"lower":   strings.ToLower,
 		"upper":   strings.ToUpper,
 		"replace": strings.ReplaceAll,
+		"dateFormat": func(date string) string {
+			logrus.Debug("date", date)
+			message := fmt.Sprintf("Error on date %s. Date format is YYYY-MM-DD.", date)
+			if len(date) != 10 {
+				logrus.Fatal(message)
+			}
+			if date[4] != '-' {
+				logrus.Fatal(message)
+			}
+			if date[7] != '-' {
+				logrus.Fatal(message)
+			}
+			// if !(date[0:4] > "1970" && date[0:4] < "9999") {
+			return date
+		},
+		"dateMonthName": func(date string) string {
+			switch date[5:7] {
+			case "01":
+				return "January"
+			case "02":
+				return "February"
+			case "03":
+				return "March"
+			case "04":
+				return "April"
+			case "05":
+				return "May"
+			case "06":
+				return "June"
+			case "07":
+				return "July"
+			case "08":
+				return "August"
+			case "09":
+				return "September"
+			case "10":
+				return "October"
+			case "11":
+				return "November"
+			case "12":
+				return "December"
+			default:
+				message := fmt.Sprintf("Error on month %s in date %s. Date format is YYYY-MM-DD.", date[5:7], date)
+				logrus.Fatal(message)
+			}
+			return ""
+		},
+		"dateMonthShortName": func(date string) string {
+			switch date[5:7] {
+			case "01":
+				return "Jan"
+			case "02":
+				return "Feb"
+			case "03":
+				return "Mar"
+			case "04":
+				return "Apr"
+			case "05":
+				return "May"
+			case "06":
+				return "Jun"
+			case "07":
+				return "Jul"
+			case "08":
+				return "Aug"
+			case "09":
+				return "Sep"
+			case "10":
+				return "Oct"
+			case "11":
+				return "Nov"
+			case "12":
+				return "Dec"
+			default:
+				message := fmt.Sprintf("Error on month %s in date %s. Date format is YYYY-MM-DD.", date[5:7], date)
+				logrus.Fatal(message)
+			}
+			return ""
+		},
+		"dateMonthYear": func(date string) string {
+			year := date[0:4]
+			switch date[5:7] {
+			case "01":
+				return "Jan " + year
+			case "02":
+				return "Feb " + year
+			case "03":
+				return "Mar " + year
+			case "04":
+				return "Apr " + year
+			case "05":
+				return "May " + year
+			case "06":
+				return "Jun " + year
+			case "07":
+				return "Jul " + year
+			case "08":
+				return "Aug " + year
+			case "09":
+				return "Sep " + year
+			case "10":
+				return "Oct " + year
+			case "11":
+				return "Nov " + year
+			case "12":
+				return "Dec " + year
+			default:
+				message := fmt.Sprintf("Error on month %s in date %s. Date format is YYYY-MM-DD.", date[5:7], date)
+				logrus.Fatal(message)
+			}
+			return ""
+		},
 	}
 	return funcMap
 }


### PR DESCRIPTION
## Todo

* Better manage errors on date format error

## Problem to be solved

### `invalid argument` occurs odd times

Theme template file

```html
{{ dateMonthName "2025-02-26" }}
{{ dateMonthShortName "2025-02-26" }}
{{ dateMonthYear "2025-02-26" }}
{{ dateFormat "2025-02-01" }}
{{ dateFormat "2025-2-02" }}
```

Errors occurs:

* 1/2: `Expected error: Error on date 2025-2-02. Date format is YYYY-MM-DD.`
* 2/2: Unexpected error: `invalid argument`
